### PR TITLE
Multiple J, K mat buffer and atomic add refinement

### DIFF
--- a/pfock/fock_task.c
+++ b/pfock/fock_task.c
@@ -154,7 +154,7 @@ void fock_task_batched(
         int nf = nt/ncpu_f;
         double *F_MN = &(F1[nf * sizeX1 * num_dmat]);
         double *F_PQ = &(F2[nf * sizeX2 * num_dmat]);
-        double *F_NQ = &(F3[nf * sizeX3 * num_dmat]);
+        double *F_NQ = F3;
         double *F_MP = &(F4[nf * sizeX4 * num_dmat]);
         double *F_MQ = &(F5[nf * sizeX5 * num_dmat]);
         double *F_NP = &(F6[nf * sizeX6 * num_dmat]);
@@ -376,7 +376,7 @@ void fock_task_nonbatch(
         int nf = nt/ncpu_f;
         double *F_MN = &(F1[nf * sizeX1 * num_dmat]);
         double *F_PQ = &(F2[nf * sizeX2 * num_dmat]);
-        double *F_NQ = &(F3[nf * sizeX3 * num_dmat]);
+        double *F_NQ = F3;
         double *F_MP = &(F4[nf * sizeX4 * num_dmat]);
         double *F_MQ = &(F5[nf * sizeX5 * num_dmat]);
         double *F_NP = &(F6[nf * sizeX6 * num_dmat]);
@@ -476,7 +476,7 @@ void reset_F(int numF, int num_dmat, double *F1, double *F2, double *F3,
             F2[k] = 0.0;
         }
         #pragma omp for nowait
-        for (int k = 0; k < numF * sizeX3 * num_dmat; k++) {
+        for (int k = 0; k <    1 * sizeX3 * num_dmat; k++) {
             F3[k] = 0.0;
         }
         #pragma omp for nowait
@@ -517,12 +517,6 @@ void reduce_F(int numF, int num_dmat,
         for (int k = 0; k < sizeX2 * num_dmat; k++) {
             for (int p = 1; p < numF; p++) {
                 F2[k] += F2[k + p * sizeX2 * num_dmat];
-            }
-        }
-		#pragma omp for
-        for (int k = 0; k < sizeX3 * num_dmat; k++) {
-            for (int p = 1; p < numF; p++) {
-                F3[k] += F3[k + p * sizeX3 * num_dmat];
             }
         }
         #pragma omp for

--- a/pfock/pfock.c
+++ b/pfock/pfock.c
@@ -686,13 +686,14 @@ static PFockStatus_t create_buffers (PFock_t pfock)
     }
     
     int sizeX4 = maxrowfuncs * maxcolfuncs;
-    int sizeX6 = maxrowsize * maxcolfuncs;
+    int sizeX6 = maxrowsize  * maxcolfuncs;
     int sizeX5 = maxrowfuncs * maxcolsize;
     pfock->sizeX4 = sizeX4;
     pfock->sizeX5 = sizeX5;
     pfock->sizeX6 = sizeX6;
     pfock->ncpu_f = ncpu_f;
     int numF = pfock->numF = (nthreads + ncpu_f - 1)/ncpu_f;
+	if (myrank == 0) printf("ncpu_f, numF = %d, %d\n", ncpu_f, numF);
     // allocation
 
     pfock->F1 = (double *)PFOCK_MALLOC(sizeof(double) * sizeX1 *
@@ -700,7 +701,7 @@ static PFockStatus_t create_buffers (PFock_t pfock)
     pfock->F2 = (double *)PFOCK_MALLOC(sizeof(double) * sizeX2 *
         numF * pfock->max_numdmat2); 
     pfock->F3 = (double *)PFOCK_MALLOC(sizeof(double) * sizeX3 *
-        pfock->max_numdmat2);
+        numF * pfock->max_numdmat2);
     pfock->F4 = (double *)PFOCK_MALLOC(sizeof(double) * sizeX4 *
         numF * pfock->max_numdmat2);
     pfock->F5 = (double *)PFOCK_MALLOC(sizeof(double) * sizeX5 *

--- a/pfock/pfock.c
+++ b/pfock/pfock.c
@@ -701,7 +701,7 @@ static PFockStatus_t create_buffers (PFock_t pfock)
     pfock->F2 = (double *)PFOCK_MALLOC(sizeof(double) * sizeX2 *
         numF * pfock->max_numdmat2); 
     pfock->F3 = (double *)PFOCK_MALLOC(sizeof(double) * sizeX3 *
-        numF * pfock->max_numdmat2);
+           1 * pfock->max_numdmat2);
     pfock->F4 = (double *)PFOCK_MALLOC(sizeof(double) * sizeX4 *
         numF * pfock->max_numdmat2);
     pfock->F5 = (double *)PFOCK_MALLOC(sizeof(double) * sizeX5 *

--- a/pfock/pfock.c
+++ b/pfock/pfock.c
@@ -157,59 +157,59 @@ static PFockStatus_t init_fock(PFock_t pfock)
 static void recursive_bisection (int *rowptr, int first, int last,
                                  int npartitions, int *partition_ptr)
 {
-	int offset = rowptr[first];
-	int nnz = rowptr[last] - rowptr[first];
+    int offset = rowptr[first];
+    int nnz = rowptr[last] - rowptr[first];
 
-	if(npartitions == 1)
-	{
-		partition_ptr[0] = first;
-		return;
-	}
+    if(npartitions == 1)
+    {
+        partition_ptr[0] = first;
+        return;
+    }
 
-	int left = npartitions/2;
-	double ideal = ((double)nnz * (double)left)/npartitions;
-	int i;
-	for(i = first; i < last; i++)
-	{
-		double count = rowptr[i] - offset;
-		double next_count = rowptr[i + 1] - offset;
-		if(next_count > ideal)
-		{
-			if(next_count - ideal > ideal - count)
-			{
-				recursive_bisection(rowptr, first, i, left, partition_ptr);
-				recursive_bisection(rowptr, i, last,
+    int left = npartitions/2;
+    double ideal = ((double)nnz * (double)left)/npartitions;
+    int i;
+    for(i = first; i < last; i++)
+    {
+        double count = rowptr[i] - offset;
+        double next_count = rowptr[i + 1] - offset;
+        if(next_count > ideal)
+        {
+            if(next_count - ideal > ideal - count)
+            {
+                recursive_bisection(rowptr, first, i, left, partition_ptr);
+                recursive_bisection(rowptr, i, last,
                                     npartitions - left, partition_ptr + left);
-				return;
-			}
-			else
-			{
-				recursive_bisection(rowptr, first, i + 1, left, partition_ptr);
-				recursive_bisection(rowptr, i + 1, last,
+                return;
+            }
+            else
+            {
+                recursive_bisection(rowptr, first, i + 1, left, partition_ptr);
+                recursive_bisection(rowptr, i + 1, last,
                                     npartitions - left, partition_ptr + left);
-				return;
-			}
-		}
-	}
+                return;
+            }
+        }
+    }
 }
 
 
 static int nnz_partition (int m, int nnz, int min_nrows,
                           int *rowptr, int npartitions, int *partition_ptr)
 {
-	recursive_bisection(rowptr, 0, m, npartitions, partition_ptr);
-	partition_ptr[npartitions] = m;
+    recursive_bisection(rowptr, 0, m, npartitions, partition_ptr);
+    partition_ptr[npartitions] = m;
 
-	for (int i = 0; i < npartitions; i++)
-	{
-		int nrows = partition_ptr[i + 1] - partition_ptr[i];
-		if (nrows < min_nrows)
-		{
-			return -1;
-		}
-	}
+    for (int i = 0; i < npartitions; i++)
+    {
+        int nrows = partition_ptr[i + 1] - partition_ptr[i];
+        if (nrows < min_nrows)
+        {
+            return -1;
+        }
+    }
     
-	return 0;
+    return 0;
 }
 
 
@@ -693,9 +693,9 @@ static PFockStatus_t create_buffers (PFock_t pfock)
     pfock->sizeX6 = sizeX6;
     pfock->ncpu_f = ncpu_f;
     int numF = pfock->numF = (nthreads + ncpu_f - 1)/ncpu_f;
-	if (myrank == 0) printf("ncpu_f, numF = %d, %d\n", ncpu_f, numF);
-    // allocation
+    if (myrank == 0) printf("%d threads will share a buffer of J, K matrix, %d copies in total\n", ncpu_f, numF);
 
+    // allocation
     pfock->F1 = (double *)PFOCK_MALLOC(sizeof(double) * sizeX1 *
         numF * pfock->max_numdmat2);
     pfock->F2 = (double *)PFOCK_MALLOC(sizeof(double) * sizeX2 *

--- a/pfock/update_F.h
+++ b/pfock/update_F.h
@@ -65,7 +65,7 @@ static void update_global_blocks(
 		
 		direct_update_block(J_PQ, ldPQ, J_PQ_buf, dimQ, dimP, dimQ);
 		direct_update_block(K_MQ, ldMQ, K_MQ_buf, dimQ, dimM, dimQ);
-		direct_update_block(K_NQ, ldNQ, K_NQ_buf, dimQ, dimN, dimQ);
+		atomic_update_block(K_NQ, ldNQ, K_NQ_buf, dimQ, dimN, dimQ);  // K_NQ always needs atomic update
 	}
 }
 

--- a/pscf/scf.c
+++ b/pscf/scf.c
@@ -14,6 +14,9 @@
 #include "CInt.h"
 #include "purif.h"
 
+// Notice: for these four parameters, optimizations in pfock are tested 
+// with current values, I'm not sure if we can change these values
+// huangh223, 2018-05-01
 #define MAX_NUM_D    1
 #define NUM_D        1
 #define USE_D_ID     0


### PR DESCRIPTION
The original program uses multiple buffers of F1, F2, F4, F5, F6 matrices for different threads. However it creates a private copy of F1, F2, F4, F5, F6 for each thread but still use atomic add for F1, F2, F4, F5, F6. The commits in this merge fixed this problem. 