### PR TITLE
fix deadlock issue when incorrect command arguments given

### DIFF
--- a/pscf/scf.c
+++ b/pscf/scf.c
@@ -263,8 +263,7 @@ int main (int argc, char **argv)
     if (myrank == 0) {
         if (argc != 8) {
             usage(argv[0]);
-            MPI_Finalize();
-            exit(0);
+            MPI_Abort(MPI_COMM_WORLD,argc);
         }
         // init parameters
         nprow_fock = atoi(argv[3]);


### PR DESCRIPTION
MPI_Finalize was called inside of a "if (rank==0)" block, which will
deadlock when more than one process is used, because all but rank 0
never enter MPI_Finalize.  using MPI_Abort is correct and more
appropriate anyways, given this is an erroneous termination.

Signed-off-by: Jeff Hammond <jeff.science@gmail.com>