### PR TITLE
Fix pragma simd warnings

### DIFF
--- a/GTPragma.h
+++ b/GTPragma.h
@@ -1,0 +1,30 @@
+#ifndef GTPRAGMA_H_
+#define GTPRAGMA_H_
+
+/* C99 or C++11 */
+#if (( __STDC_VERSION__ >= 199901L ) || (__cplusplus >= 201103L ))
+# define PRAGMA(x) _Pragma(#x)
+
+/* OpenMP 4+ */
+# if defined(_OPENMP) && (_OPENMP >= 201307)
+#  define PRAGMA_SIMD PRAGMA(omp simd)
+
+/* Intel */
+# elif defined(__INTEL_COMPILER) && (__INTEL_COMPILER >= 1800)
+#  define PRAGMA_SIMD PRAGMA(ivdep) /* PRAGMA(vector always) might be better... */
+# elif defined(__INTEL_COMPILER) && (__INTEL_COMPILER < 1800)
+#  define PRAGMA_SIMD PRAGMA(simd)
+
+/* Unsupported */
+# else
+#  warning No definition of PRAGMA_SIMD for your compiler...
+#  define PRAGMA_SIMD
+# endif
+
+/* C90 or older */
+#else
+# warning Without a C99/C++11 compiler, PRAGMA_SIMD does nothing.
+# define PRAGMA_SIMD
+#endif
+
+#endif // GTPRAGMA_H_

--- a/make.in
+++ b/make.in
@@ -36,6 +36,7 @@ OPTFLAGS  = -qno-offload
 CFLAGS    = -O3 -Wall -qopenmp -std=gnu99 -fasm-blocks -g -xHost
 CFLAGS   += -Wunknown-pragmas -Wunused-variable
 CFLAGS   += ${OPTFLAGS}
+CFLAGS   += -I..
 
 BLAS_LIBS      = -lmkl_intel_lp64 -lmkl_core -lmkl_intel_thread -lpthread -lm 
 SCALAPACK_LIBS = -lmkl_scalapack_lp64 -lmkl_blacs_intelmpi_lp64

--- a/pfock/config.h
+++ b/pfock/config.h
@@ -1,7 +1,6 @@
 #ifndef __CONFIG_H__
 #define __CONFIG_H__
 
-
 #define GA_NB
 #define MIN(a, b)    ((a) < (b) ? (a) : (b))
 #define MAX(a, b)    ((a) > (b) ? (a) : (b))

--- a/pfock/fock_task.c
+++ b/pfock/fock_task.c
@@ -670,7 +670,7 @@ void reduce_F(double *F1, double *F2, double *F3, int maxrowsize, int maxcolsize
         for (int p = 1; p < num_dup_F; p++)
         {
             int offset = p * F_PQ_block_size;
-            #pragma simd
+            PRAGMA_SIMD
             for (int k = spos; k < epos; k++)
                 F_PQ_blocks[k] += F_PQ_blocks[offset + k];
         }

--- a/pfock/one_electron.c
+++ b/pfock/one_electron.c
@@ -184,7 +184,7 @@ void my_peig(GTMatrix_t gtm_A, GTMatrix_t gtm_B, int n, int nprow, int npcol, do
     
     for (int i = 0; i < nrows; i++) 
     {
-        #pragma simd
+        PRAGMA_SIMD
         for (int j = 0; j < ncols; j++) 
             A[j * nrows + i] = Z[i * ncols + j];
     }

--- a/pfock/pfock.c
+++ b/pfock/pfock.c
@@ -1191,14 +1191,14 @@ PFockStatus_t PFock_createOvlMat(PFock_t pfock, BasisSet_t basis)
     double *lambda_vector = (double *)malloc(nfuncs_col * sizeof (double));
     assert (lambda_vector != NULL);   
 
-    #pragma simd
+    PRAGMA_SIMD
     for (int j = 0; j < nfuncs_col; j++) 
         lambda_vector[j] = 1.0 / sqrt(eval[j + lo1tmp]);
     free(eval);
     
     for (int i = 0; i < nfuncs_row; i++)  
     {
-        #pragma simd
+        PRAGMA_SIMD
         for (int j = 0; j < nfuncs_col; j++) 
             blockS[i * ld + j] = blocktmp[i * ld + j] * lambda_vector[j];
     }

--- a/pfock/pfock.h
+++ b/pfock/pfock.h
@@ -5,6 +5,8 @@
 #include <omp.h>
 #include "CInt.h"
 
+#include "GTPragma.h"
+
 #include "GTMatrix.h"
 #include "GTM_Task_Queue.h"
 #include "utils.h"

--- a/pfock/update_F.h
+++ b/pfock/update_F.h
@@ -30,7 +30,7 @@ static inline void atomic_add_vector(double *dst, double *src, int length)
 
 static inline void direct_add_vector(double *dst, double *src, int length)
 {
-    #pragma simd
+    PRAGMA_SIMD
     for (int i = 0; i < length; i++) 
         dst[i] += src[i];
 }

--- a/pscf/pdgemm.c
+++ b/pscf/pdgemm.c
@@ -72,7 +72,7 @@ void myTranspose(double *src, double *dst, int nrows, int ncols)
         
         for (int icol = icol0; icol < icol1; icol++)
         {
-            #pragma simd
+            PRAGMA_SIMD
             for (int irow = irow0; irow < irow1; irow++)
             {
                 int src_idx  = irow * ncols + icol;
@@ -520,7 +520,7 @@ void allocate_tmpbuf(int nrows, int ncols, int *nr, int *nc, tmpbuf_t *tmpbuf)
     tmpbuf->C_i = tmpbuf->S_i + block_size_align64b;
 
     #pragma omp parallel for schedule(static)
-    #pragma simd
+    PRAGMA_SIMD
     for (int i = 0; i < nrows0 * ncols0; i++)
     {
         tmpbuf->A[i] = 0;

--- a/pscf/pdgemm.c
+++ b/pscf/pdgemm.c
@@ -519,8 +519,7 @@ void allocate_tmpbuf(int nrows, int ncols, int *nr, int *nc, tmpbuf_t *tmpbuf)
     tmpbuf->S_i = tmpbuf->A_i + block_size_align64b;
     tmpbuf->C_i = tmpbuf->S_i + block_size_align64b;
 
-    #pragma omp parallel for schedule(static)
-    PRAGMA_SIMD
+    #pragma omp parallel for simd schedule(static)
     for (int i = 0; i < nrows0 * ncols0; i++)
     {
         tmpbuf->A[i] = 0;

--- a/pscf/pdgemm.h
+++ b/pscf/pdgemm.h
@@ -4,6 +4,7 @@
 
 #include <mpi.h>
 
+#include "GTPragma.h"
 
 typedef struct _tmpbuf_t
 {

--- a/pscf/purif.c
+++ b/pscf/purif.c
@@ -111,8 +111,7 @@ static void config_purif(purif_t * purif, int purif_offload)
         purif->b_mat[i * LDBMAT + i] = 0.0;
     }
 
-    #pragma omp parallel for schedule(static)
-    PRAGMA_SIMD
+    #pragma omp parallel for simd schedule(static)
     for(int i=0; i < nrows * ncols; i++)
     {
         purif->D_block[i]  = 0.0;
@@ -387,8 +386,7 @@ int compute_purification(purif_t * purif, double *F_block, double *D_block)
                 ncp1  = 1.0 - c;
                 if (c < 0.5) 
                 {
-                    #pragma omp parallel for reduction(+: errnorm_local)
-                    PRAGMA_SIMD
+                    #pragma omp parallel for simd reduction(+: errnorm_local)
                     for (int i = 0; i < nrows * ncols; i++) 
                     {
                         double D_D2 = D_block[i] - D2_block[i];
@@ -398,8 +396,7 @@ int compute_purification(purif_t * purif, double *F_block, double *D_block)
                         D_block[i] = (n2cp1 * D_block[i] + cp1 * D2_block[i] - D3_block[i]) / ncp1;
                     }
                 } else {
-                    #pragma omp parallel for reduction(+: errnorm_local)
-                    PRAGMA_SIMD
+                    #pragma omp parallel for simd reduction(+: errnorm_local)
                     for (int i = 0; i < nrows * ncols; i++) 
                     {
                         double D_D2 = D_block[i] - D2_block[i];

--- a/pscf/purif.c
+++ b/pscf/purif.c
@@ -112,7 +112,7 @@ static void config_purif(purif_t * purif, int purif_offload)
     }
 
     #pragma omp parallel for schedule(static)
-    #pragma simd
+    PRAGMA_SIMD
     for(int i=0; i < nrows * ncols; i++)
     {
         purif->D_block[i]  = 0.0;
@@ -388,7 +388,7 @@ int compute_purification(purif_t * purif, double *F_block, double *D_block)
                 if (c < 0.5) 
                 {
                     #pragma omp parallel for reduction(+: errnorm_local)
-                    #pragma simd
+                    PRAGMA_SIMD
                     for (int i = 0; i < nrows * ncols; i++) 
                     {
                         double D_D2 = D_block[i] - D2_block[i];
@@ -399,7 +399,7 @@ int compute_purification(purif_t * purif, double *F_block, double *D_block)
                     }
                 } else {
                     #pragma omp parallel for reduction(+: errnorm_local)
-                    #pragma simd
+                    PRAGMA_SIMD
                     for (int i = 0; i < nrows * ncols; i++) 
                     {
                         double D_D2 = D_block[i] - D2_block[i];

--- a/pscf/scf.c
+++ b/pscf/scf.c
@@ -86,7 +86,7 @@ static void initial_guess(PFock_t pfock, BasisSet_t basis, int ispurif,
         );
         R *= 0.5;
         for (int x = rowstart; x <= rowend; x++) 
-            #pragma simd
+            PRAGMA_SIMD
             for (int y = colstart; y <= colend; y++) 
                 D_block[(x - rowstart) * ldD + (y - colstart)] *= R;
     }
@@ -110,7 +110,7 @@ static double compute_energy(purif_t * purif, double *F_block, double *D_block)
         for (int i = 0; i < nrows; i++) 
         {
             int ldx_i = i * ldx;
-            #pragma simd
+            PRAGMA_SIMD
             for (int j = 0; j < ncols; j++) 
             {
                 F_block[ldx_i + j] += H_block[ldx_i + j];


### PR DESCRIPTION
Intel 18 deprecates `#pragma simd`.  This is one way to avoid those issues.

Because I folded `simd` into `omp parallel for` where necessary, this won't compiler with older OpenMP anymore.  That is easy to fix using a similar trick, but I'm not sure if it matters to you.  Let me know and I will fix it.